### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = ["asyncalchemy/tests"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-sqlalchemy = "^1.3.0"
+sqlalchemy = "^1.2.0"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Expanded SQLAlchemy version support,  now supports 1.2 and up.